### PR TITLE
ci: add main workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run type-check
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "type-check": "tsc --noEmit",
     "test": "node --test"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add main CI workflow for lint, type-check, and test
- add type-check script for tsc

## Changes
- new `.github/workflows/ci.yml` running on push/PR
- add `npm run type-check` script

## Testing
- not run (workflow only)

Closes #63

## Summary by Sourcery

Introduce a main CI workflow to run linting, TypeScript type-checking, and tests on pushes and pull requests.

Build:
- Add npm script for TypeScript type-checking using tsc with no emit.

CI:
- Add GitHub Actions CI workflow to run lint, type-check, and test jobs on pushes and pull requests to main and master branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established a continuous integration pipeline with automated linting, type-checking, and testing workflows to ensure consistent code quality standards across the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->