### PR TITLE
feat(#91): Case resolution workflow

### DIFF
--- a/src/components/cases/CaseResolutionPanel.tsx
+++ b/src/components/cases/CaseResolutionPanel.tsx
@@ -7,7 +7,14 @@ import type {
   CaseRetentionFlags,
   CaseResolutionType,
 } from "@/types";
+import {
+  RESOLUTION_TYPE_LABELS,
+  RESOLUTION_TYPE_DESCRIPTIONS,
+  SENSITIVE_RESOLUTION_TYPES,
+  POSITIVE_RESOLUTION_TYPES,
+} from "@/types/case-resolution.types";
 import { cn } from "@/lib";
+import { ResolutionConfirmDialog } from "./ResolutionConfirmDialog";
 
 interface CaseResolutionPanelProps {
   caseId: string;
@@ -19,14 +26,22 @@ interface ResolutionResponse {
   retention: CaseRetentionFlags | null;
 }
 
-const resolutionTypeOptions: Array<{ value: CaseResolutionType; label: string }> = [
-  { value: "found_safe", label: "Found safe" },
-  { value: "found_deceased", label: "Found deceased" },
-  { value: "unfounded", label: "Unfounded" },
-  { value: "duplicate", label: "Duplicate" },
-  { value: "cancelled", label: "Cancelled" },
-  { value: "transferred", label: "Transferred" },
-  { value: "other", label: "Other" },
+const resolutionTypeOptions: Array<{
+  value: CaseResolutionType;
+  label: string;
+  category: "positive" | "neutral" | "sensitive";
+}> = [
+  { value: "found_safe", label: RESOLUTION_TYPE_LABELS.found_safe, category: "positive" },
+  { value: "returned_home", label: RESOLUTION_TYPE_LABELS.returned_home, category: "positive" },
+  { value: "located_elsewhere", label: RESOLUTION_TYPE_LABELS.located_elsewhere, category: "positive" },
+  { value: "found_deceased", label: RESOLUTION_TYPE_LABELS.found_deceased, category: "sensitive" },
+  { value: "closed_insufficient_info", label: RESOLUTION_TYPE_LABELS.closed_insufficient_info, category: "neutral" },
+  { value: "false_report", label: RESOLUTION_TYPE_LABELS.false_report, category: "sensitive" },
+  { value: "unfounded", label: RESOLUTION_TYPE_LABELS.unfounded, category: "neutral" },
+  { value: "duplicate", label: RESOLUTION_TYPE_LABELS.duplicate, category: "neutral" },
+  { value: "cancelled", label: RESOLUTION_TYPE_LABELS.cancelled, category: "neutral" },
+  { value: "transferred", label: RESOLUTION_TYPE_LABELS.transferred, category: "neutral" },
+  { value: "other", label: RESOLUTION_TYPE_LABELS.other, category: "neutral" },
 ];
 
 const retentionStatusOptions = [
@@ -50,6 +65,16 @@ export default function CaseResolutionPanel({ caseId }: CaseResolutionPanelProps
   const [isSaving, setIsSaving] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
 
+  // Success story consent
+  const [successStoryConsent, setSuccessStoryConsent] = useState(false);
+  const [successStoryNotes, setSuccessStoryNotes] = useState("");
+
+  // Confirmation dialog state
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const [pendingAction, setPendingAction] = useState<
+    "save_draft" | "submit_for_signoff" | "sign_off" | "close" | null
+  >(null);
+
   const loadResolution = useCallback(async () => {
     const response = await fetch(`/api/cases/${caseId}/resolution`);
     if (!response.ok) {
@@ -65,6 +90,12 @@ export default function CaseResolutionPanel({ caseId }: CaseResolutionPanelProps
     }
     if (data.resolution?.outcomeNotes) {
       setOutcomeNotes(data.resolution.outcomeNotes);
+    }
+    if (data.resolution?.successStoryConsent !== undefined) {
+      setSuccessStoryConsent(data.resolution.successStoryConsent);
+    }
+    if (data.resolution?.successStoryNotes) {
+      setSuccessStoryNotes(data.resolution.successStoryNotes);
     }
     if (data.retention) {
       setRetentionStatus(data.retention.retentionStatus);
@@ -87,6 +118,46 @@ export default function CaseResolutionPanel({ caseId }: CaseResolutionPanelProps
       .replace(/_/g, " ")
       .replace(/\b\w/g, (char) => char.toUpperCase());
   }, [resolution?.status]);
+
+  const isSensitiveResolution = useMemo(() => {
+    return resolutionType && SENSITIVE_RESOLUTION_TYPES.includes(resolutionType as CaseResolutionType);
+  }, [resolutionType]);
+
+  const isPositiveResolution = useMemo(() => {
+    return resolutionType && POSITIVE_RESOLUTION_TYPES.includes(resolutionType as CaseResolutionType);
+  }, [resolutionType]);
+
+  const resolutionDescription = useMemo(() => {
+    if (!resolutionType) return null;
+    return RESOLUTION_TYPE_DESCRIPTIONS[resolutionType as CaseResolutionType];
+  }, [resolutionType]);
+
+  const handleActionClick = (
+    action: "save_draft" | "submit_for_signoff" | "sign_off" | "close"
+  ) => {
+    // For closing with sensitive resolutions, show confirmation dialog
+    if (action === "close" && isSensitiveResolution && resolutionType) {
+      setPendingAction(action);
+      setShowConfirmDialog(true);
+      return;
+    }
+
+    // For other actions, proceed directly
+    void saveResolution(action);
+  };
+
+  const handleConfirmResolution = () => {
+    if (pendingAction) {
+      void saveResolution(pendingAction);
+    }
+    setShowConfirmDialog(false);
+    setPendingAction(null);
+  };
+
+  const handleCancelResolution = () => {
+    setShowConfirmDialog(false);
+    setPendingAction(null);
+  };
 
   const saveResolution = async (
     action: "save_draft" | "submit_for_signoff" | "sign_off" | "close"
@@ -111,6 +182,8 @@ export default function CaseResolutionPanel({ caseId }: CaseResolutionPanelProps
           : null,
         legalHold,
       },
+      successStoryConsent,
+      successStoryNotes: successStoryNotes || undefined,
     };
 
     const response = await fetch(`/api/cases/${caseId}/resolution`, {
@@ -161,205 +234,336 @@ export default function CaseResolutionPanel({ caseId }: CaseResolutionPanelProps
   };
 
   return (
-    <div className="space-y-6 rounded-xl border border-gray-200 bg-white p-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h2 className="text-lg font-semibold text-gray-900">
-            Case Resolution Workflow
-          </h2>
-          <p className="text-sm text-gray-500">
-            Status: <span className="font-medium text-gray-800">{statusLabel}</span>
-          </p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            onClick={() => saveResolution("save_draft")}
-            disabled={isSaving}
-            className={cn(
-              "rounded-lg border border-gray-200 px-3 py-2 text-xs font-medium text-gray-700",
-              isSaving ? "opacity-60" : "hover:bg-gray-50"
-            )}
-          >
-            Save draft
-          </button>
-          <button
-            type="button"
-            onClick={() => saveResolution("submit_for_signoff")}
-            disabled={isSaving}
-            className={cn(
-              "rounded-lg bg-amber-500 px-3 py-2 text-xs font-medium text-white",
-              isSaving ? "opacity-60" : "hover:bg-amber-600"
-            )}
-          >
-            Submit for LE sign-off
-          </button>
-          <button
-            type="button"
-            onClick={() => saveResolution("sign_off")}
-            disabled={isSaving}
-            className={cn(
-              "rounded-lg bg-blue-600 px-3 py-2 text-xs font-medium text-white",
-              isSaving ? "opacity-60" : "hover:bg-blue-700"
-            )}
-          >
-            LE sign-off
-          </button>
-          <button
-            type="button"
-            onClick={() => saveResolution("close")}
-            disabled={isSaving}
-            className={cn(
-              "rounded-lg bg-emerald-600 px-3 py-2 text-xs font-medium text-white",
-              isSaving ? "opacity-60" : "hover:bg-emerald-700"
-            )}
-          >
-            Close case
-          </button>
-        </div>
-      </div>
-
-      {message ? (
-        <p className="rounded-lg bg-gray-50 px-3 py-2 text-sm text-gray-600">
-          {message}
-        </p>
-      ) : null}
-
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <div className="space-y-3">
-          <label className="text-sm font-medium text-gray-700" htmlFor="resolutionType">
-            Resolution type
-          </label>
-          <select
-            id="resolutionType"
-            value={resolutionType}
-            onChange={(event) =>
-              setResolutionType(event.target.value as CaseResolutionType)
-            }
-            className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
-          >
-            <option value="">Select resolution type</option>
-            {resolutionTypeOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-          <label className="text-sm font-medium text-gray-700" htmlFor="outcomeNotes">
-            Outcome notes
-          </label>
-          <textarea
-            id="outcomeNotes"
-            value={outcomeNotes}
-            onChange={(event) => setOutcomeNotes(event.target.value)}
-            rows={4}
-            className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
-            placeholder="Document resolution outcome and key details"
-          />
-        </div>
-
-        <div className="space-y-3">
-          <label className="text-sm font-medium text-gray-700">Outcome document</label>
-          <div className="rounded-lg border border-dashed border-gray-200 p-3">
-            <input
-              type="file"
-              onChange={(event) =>
-                setPendingDocument(event.target.files?.[0] ?? null)
-              }
-              className="w-full text-sm text-gray-600"
-            />
+    <>
+      <div className="space-y-6 rounded-xl border border-gray-200 bg-white p-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">
+              Case Resolution Workflow
+            </h2>
+            <p className="text-sm text-gray-500">
+              Status: <span className="font-medium text-gray-800">{statusLabel}</span>
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
             <button
               type="button"
-              onClick={uploadDocument}
-              disabled={!pendingDocument || isSaving}
+              onClick={() => handleActionClick("save_draft")}
+              disabled={isSaving}
               className={cn(
-                "mt-3 rounded-lg bg-gray-900 px-3 py-2 text-xs font-medium text-white",
-                !pendingDocument || isSaving ? "opacity-60" : "hover:bg-gray-800"
+                "rounded-lg border border-gray-200 px-3 py-2 text-xs font-medium text-gray-700",
+                isSaving ? "opacity-60" : "hover:bg-gray-50"
               )}
             >
-              Upload outcome document
+              Save draft
+            </button>
+            <button
+              type="button"
+              onClick={() => handleActionClick("submit_for_signoff")}
+              disabled={isSaving}
+              className={cn(
+                "rounded-lg bg-amber-500 px-3 py-2 text-xs font-medium text-white",
+                isSaving ? "opacity-60" : "hover:bg-amber-600"
+              )}
+            >
+              Submit for LE sign-off
+            </button>
+            <button
+              type="button"
+              onClick={() => handleActionClick("sign_off")}
+              disabled={isSaving}
+              className={cn(
+                "rounded-lg bg-blue-600 px-3 py-2 text-xs font-medium text-white",
+                isSaving ? "opacity-60" : "hover:bg-blue-700"
+              )}
+            >
+              LE sign-off
+            </button>
+            <button
+              type="button"
+              onClick={() => handleActionClick("close")}
+              disabled={isSaving || !resolutionType}
+              className={cn(
+                "rounded-lg px-3 py-2 text-xs font-medium text-white",
+                isSensitiveResolution
+                  ? "bg-rose-600 hover:bg-rose-700"
+                  : "bg-emerald-600 hover:bg-emerald-700",
+                (isSaving || !resolutionType) && "opacity-60"
+              )}
+            >
+              Close case
             </button>
           </div>
-          <div className="space-y-2">
-            {documents.length === 0 ? (
-              <p className="text-sm text-gray-500">No documents uploaded yet.</p>
-            ) : (
-              documents.map((doc) => (
-                <div
-                  key={doc.id}
-                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-700"
-                >
-                  <div className="font-medium">{doc.fileName}</div>
-                  <div className="text-xs text-gray-500">
-                    {doc.fileType || "Unknown type"} • {new Date(doc.createdAt).toLocaleString()}
-                  </div>
-                </div>
-              ))
-            )}
-          </div>
         </div>
-      </div>
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <div className="space-y-3">
-          <h3 className="text-sm font-semibold text-gray-900">Family notification log</h3>
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-            <input
-              type="text"
-              value={familyChannel}
-              onChange={(event) => setFamilyChannel(event.target.value)}
-              placeholder="Channel (phone, email)"
-              className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
-            />
-            <input
-              type="text"
-              value={familyNotes}
-              onChange={(event) => setFamilyNotes(event.target.value)}
-              placeholder="Notes (optional)"
-              className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
-            />
-          </div>
-          <p className="text-xs text-gray-500">
-            Notification is logged when you save or submit for sign-off.
+        {message ? (
+          <p className="rounded-lg bg-gray-50 px-3 py-2 text-sm text-gray-600">
+            {message}
           </p>
-        </div>
+        ) : null}
 
-        <div className="space-y-3">
-          <h3 className="text-sm font-semibold text-gray-900">Retention policy flags</h3>
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <div className="space-y-3">
+            <label className="text-sm font-medium text-gray-700" htmlFor="resolutionType">
+              Resolution type
+            </label>
             <select
-              value={retentionStatus}
-              onChange={(event) => setRetentionStatus(event.target.value)}
-              className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
+              id="resolutionType"
+              value={resolutionType}
+              onChange={(event) =>
+                setResolutionType(event.target.value as CaseResolutionType)
+              }
+              className={cn(
+                "w-full rounded-lg border px-3 py-2 text-sm",
+                isSensitiveResolution
+                  ? "border-rose-300 bg-rose-50"
+                  : isPositiveResolution
+                  ? "border-emerald-300 bg-emerald-50"
+                  : "border-gray-200"
+              )}
             >
-              {retentionStatusOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
+              <option value="">Select resolution type</option>
+              <optgroup label="Positive Outcomes">
+                {resolutionTypeOptions
+                  .filter((o) => o.category === "positive")
+                  .map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+              </optgroup>
+              <optgroup label="Case Closure">
+                {resolutionTypeOptions
+                  .filter((o) => o.category === "neutral")
+                  .map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+              </optgroup>
+              <optgroup label="Sensitive (Requires Confirmation)">
+                {resolutionTypeOptions
+                  .filter((o) => o.category === "sensitive")
+                  .map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+              </optgroup>
             </select>
-            <input
-              type="date"
-              value={scheduledPurgeAt}
-              onChange={(event) => setScheduledPurgeAt(event.target.value)}
-              className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
+
+            {resolutionDescription && (
+              <p
+                className={cn(
+                  "text-xs rounded-lg p-2",
+                  isSensitiveResolution
+                    ? "bg-rose-50 text-rose-700"
+                    : isPositiveResolution
+                    ? "bg-emerald-50 text-emerald-700"
+                    : "bg-gray-50 text-gray-600"
+                )}
+              >
+                {resolutionDescription}
+              </p>
+            )}
+
+            <label className="text-sm font-medium text-gray-700" htmlFor="outcomeNotes">
+              Outcome notes
+            </label>
+            <textarea
+              id="outcomeNotes"
+              value={outcomeNotes}
+              onChange={(event) => setOutcomeNotes(event.target.value)}
+              rows={4}
+              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+              placeholder="Document resolution outcome and key details"
             />
           </div>
-          <label className="flex items-center gap-2 text-sm text-gray-600">
-            <input
-              type="checkbox"
-              checked={legalHold}
-              onChange={(event) => setLegalHold(event.target.checked)}
-            />
-            Legal hold
-          </label>
-          {retention?.scheduledPurgeAt ? (
-            <p className="text-xs text-gray-500">
-              Current purge date: {new Date(retention.scheduledPurgeAt).toLocaleDateString()}
+
+          <div className="space-y-3">
+            <label className="text-sm font-medium text-gray-700">Outcome document</label>
+            <div className="rounded-lg border border-dashed border-gray-200 p-3">
+              <input
+                type="file"
+                onChange={(event) =>
+                  setPendingDocument(event.target.files?.[0] ?? null)
+                }
+                className="w-full text-sm text-gray-600"
+              />
+              <button
+                type="button"
+                onClick={uploadDocument}
+                disabled={!pendingDocument || isSaving}
+                className={cn(
+                  "mt-3 rounded-lg bg-gray-900 px-3 py-2 text-xs font-medium text-white",
+                  !pendingDocument || isSaving ? "opacity-60" : "hover:bg-gray-800"
+                )}
+              >
+                Upload outcome document
+              </button>
+            </div>
+            <div className="space-y-2">
+              {documents.length === 0 ? (
+                <p className="text-sm text-gray-500">No documents uploaded yet.</p>
+              ) : (
+                documents.map((doc) => (
+                  <div
+                    key={doc.id}
+                    className="rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-700"
+                  >
+                    <div className="font-medium">{doc.fileName}</div>
+                    <div className="text-xs text-gray-500">
+                      {doc.fileType || "Unknown type"} • {new Date(doc.createdAt).toLocaleString()}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Success Story Consent - only show for positive resolutions */}
+        {isPositiveResolution && (
+          <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-4">
+            <h3 className="text-sm font-semibold text-emerald-900">Success Story Option</h3>
+            <p className="mt-1 text-xs text-emerald-700">
+              Would the family like to share their story to help others? This is completely optional.
             </p>
-          ) : null}
+            <div className="mt-3 space-y-3">
+              <label className="flex items-center gap-2 text-sm text-emerald-800">
+                <input
+                  type="checkbox"
+                  checked={successStoryConsent}
+                  onChange={(event) => setSuccessStoryConsent(event.target.checked)}
+                  className="rounded border-emerald-300 text-emerald-600 focus:ring-emerald-500"
+                />
+                Family consents to share their success story
+              </label>
+              {successStoryConsent && (
+                <textarea
+                  value={successStoryNotes}
+                  onChange={(event) => setSuccessStoryNotes(event.target.value)}
+                  rows={2}
+                  className="w-full rounded-lg border border-emerald-200 bg-white px-3 py-2 text-sm"
+                  placeholder="Additional notes about the success story (optional)"
+                />
+              )}
+            </div>
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <div className="space-y-3">
+            <h3 className="text-sm font-semibold text-gray-900">Family notification log</h3>
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <input
+                type="text"
+                value={familyChannel}
+                onChange={(event) => setFamilyChannel(event.target.value)}
+                placeholder="Channel (phone, email)"
+                className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
+              />
+              <input
+                type="text"
+                value={familyNotes}
+                onChange={(event) => setFamilyNotes(event.target.value)}
+                placeholder="Notes (optional)"
+                className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
+              />
+            </div>
+            <p className="text-xs text-gray-500">
+              Notification is logged when you save or submit for sign-off.
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            <h3 className="text-sm font-semibold text-gray-900">Retention policy flags</h3>
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <select
+                value={retentionStatus}
+                onChange={(event) => setRetentionStatus(event.target.value)}
+                className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
+              >
+                {retentionStatusOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <input
+                type="date"
+                value={scheduledPurgeAt}
+                onChange={(event) => setScheduledPurgeAt(event.target.value)}
+                className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
+              />
+            </div>
+            <label className="flex items-center gap-2 text-sm text-gray-600">
+              <input
+                type="checkbox"
+                checked={legalHold}
+                onChange={(event) => setLegalHold(event.target.checked)}
+              />
+              Legal hold
+            </label>
+            {retention?.scheduledPurgeAt ? (
+              <p className="text-xs text-gray-500">
+                Current purge date: {new Date(retention.scheduledPurgeAt).toLocaleDateString()}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        {/* Post-Resolution Actions info */}
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+          <h3 className="text-sm font-semibold text-gray-900">Post-Resolution Actions</h3>
+          <p className="mt-1 text-xs text-gray-600">
+            When this case is closed, the following automated actions will occur:
+          </p>
+          <ul className="mt-2 space-y-1 text-xs text-gray-600">
+            <li className="flex items-center gap-2">
+              <CheckIcon className="h-3 w-3 text-emerald-500" />
+              Automated thank-you sent to all helpers and volunteers
+            </li>
+            <li className="flex items-center gap-2">
+              <CheckIcon className="h-3 w-3 text-emerald-500" />
+              Active resources and alerts deactivated
+            </li>
+            <li className="flex items-center gap-2">
+              <CheckIcon className="h-3 w-3 text-emerald-500" />
+              All leads archived with resolution reference
+            </li>
+            <li className="flex items-center gap-2">
+              <CheckIcon className="h-3 w-3 text-emerald-500" />
+              Case statistics updated and compiled
+            </li>
+          </ul>
         </div>
       </div>
-    </div>
+
+      {/* Confirmation Dialog */}
+      {resolutionType && (
+        <ResolutionConfirmDialog
+          isOpen={showConfirmDialog}
+          resolutionType={resolutionType as CaseResolutionType}
+          onConfirm={handleConfirmResolution}
+          onCancel={handleCancelResolution}
+          isLoading={isSaving}
+        />
+      )}
+    </>
+  );
+}
+
+function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      stroke="currentColor"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+    </svg>
   );
 }

--- a/src/components/cases/ResolutionConfirmDialog.tsx
+++ b/src/components/cases/ResolutionConfirmDialog.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib";
+import type { CaseResolutionType } from "@/types";
+import {
+  RESOLUTION_TYPE_LABELS,
+  RESOLUTION_TYPE_DESCRIPTIONS,
+  SENSITIVE_RESOLUTION_TYPES,
+} from "@/types/case-resolution.types";
+
+interface ResolutionConfirmDialogProps {
+  isOpen: boolean;
+  resolutionType: CaseResolutionType;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+const SENSITIVE_WARNINGS: Record<string, { title: string; message: string; resources?: string[] }> = {
+  found_deceased: {
+    title: "Sensitive Resolution Confirmation",
+    message:
+      "You are about to mark this case as 'Found Deceased'. This action requires additional verification and will trigger grief support notifications to the family liaison.",
+    resources: [
+      "Grief counseling resources will be provided to the family",
+      "Law enforcement sign-off is required",
+      "Media handling protocols will be activated",
+    ],
+  },
+  false_report: {
+    title: "False Report Confirmation",
+    message:
+      "Marking this case as a false report is a serious action. All public data will be removed and the case will be flagged in the system. This may have legal implications.",
+    resources: [
+      "All public-facing information will be removed",
+      "The reporter may be subject to follow-up",
+      "Statistical data will be updated accordingly",
+    ],
+  },
+};
+
+export function ResolutionConfirmDialog({
+  isOpen,
+  resolutionType,
+  onConfirm,
+  onCancel,
+  isLoading = false,
+}: ResolutionConfirmDialogProps) {
+  const [confirmationText, setConfirmationText] = useState("");
+
+  if (!isOpen) return null;
+
+  const isSensitive = SENSITIVE_RESOLUTION_TYPES.includes(resolutionType);
+  const warning = SENSITIVE_WARNINGS[resolutionType];
+  const label = RESOLUTION_TYPE_LABELS[resolutionType];
+  const description = RESOLUTION_TYPE_DESCRIPTIONS[resolutionType];
+
+  const requiresTypedConfirmation = isSensitive;
+  const isConfirmEnabled = !requiresTypedConfirmation || confirmationText.toLowerCase() === "confirm";
+
+  const handleConfirm = () => {
+    if (isConfirmEnabled) {
+      onConfirm();
+      setConfirmationText("");
+    }
+  };
+
+  const handleCancel = () => {
+    setConfirmationText("");
+    onCancel();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      <div className="flex min-h-screen items-end justify-center px-4 pb-20 pt-4 text-center sm:block sm:p-0">
+        {/* Backdrop */}
+        <div
+          className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+          onClick={handleCancel}
+          aria-hidden="true"
+        />
+
+        {/* Center modal */}
+        <span className="hidden sm:inline-block sm:h-screen sm:align-middle" aria-hidden="true">
+          &#8203;
+        </span>
+
+        {/* Modal panel */}
+        <div className="inline-block transform overflow-hidden rounded-lg bg-white text-left align-bottom shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:align-middle">
+          {/* Header */}
+          <div
+            className={cn(
+              "px-6 py-4 border-b",
+              isSensitive ? "bg-rose-50 border-rose-200" : "bg-gray-50 border-gray-200"
+            )}
+          >
+            <div className="flex items-center gap-3">
+              {isSensitive && (
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-rose-100">
+                  <ExclamationTriangleIcon className="h-6 w-6 text-rose-600" />
+                </div>
+              )}
+              <div>
+                <h3
+                  className={cn(
+                    "text-lg font-semibold",
+                    isSensitive ? "text-rose-900" : "text-gray-900"
+                  )}
+                >
+                  {warning?.title || "Confirm Resolution"}
+                </h3>
+                <p className="text-sm text-gray-500">Resolution type: {label}</p>
+              </div>
+            </div>
+          </div>
+
+          {/* Content */}
+          <div className="px-6 py-4">
+            <p className="text-sm text-gray-600">
+              {warning?.message || description}
+            </p>
+
+            {warning?.resources && (
+              <div className="mt-4 rounded-lg bg-amber-50 p-4">
+                <h4 className="text-sm font-medium text-amber-800">Important considerations:</h4>
+                <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-amber-700">
+                  {warning.resources.map((resource, index) => (
+                    <li key={index}>{resource}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {requiresTypedConfirmation && (
+              <div className="mt-4">
+                <label htmlFor="confirmationText" className="block text-sm font-medium text-gray-700">
+                  Type &quot;CONFIRM&quot; to proceed
+                </label>
+                <input
+                  id="confirmationText"
+                  type="text"
+                  value={confirmationText}
+                  onChange={(e) => setConfirmationText(e.target.value)}
+                  placeholder="CONFIRM"
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-rose-500 focus:outline-none focus:ring-1 focus:ring-rose-500"
+                  disabled={isLoading}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="flex justify-end gap-3 border-t border-gray-200 bg-gray-50 px-6 py-4">
+            <button
+              type="button"
+              onClick={handleCancel}
+              disabled={isLoading}
+              className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={!isConfirmEnabled || isLoading}
+              className={cn(
+                "rounded-lg px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50",
+                isSensitive
+                  ? "bg-rose-600 hover:bg-rose-700"
+                  : "bg-cyan-600 hover:bg-cyan-700"
+              )}
+            >
+              {isLoading ? "Processing..." : "Confirm Resolution"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ExclamationTriangleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+      />
+    </svg>
+  );
+}
+
+export default ResolutionConfirmDialog;

--- a/src/types/case-resolution.types.ts
+++ b/src/types/case-resolution.types.ts
@@ -1,6 +1,10 @@
 export type CaseResolutionType =
   | "found_safe"
   | "found_deceased"
+  | "returned_home"
+  | "located_elsewhere"
+  | "closed_insufficient_info"
+  | "false_report"
   | "unfounded"
   | "duplicate"
   | "cancelled"
@@ -14,6 +18,49 @@ export type CaseResolutionStatus =
   | "closed";
 
 export type RetentionStatus = "active" | "purge_scheduled" | "on_hold";
+
+/** Resolution types that require extra confirmation due to sensitive nature */
+export const SENSITIVE_RESOLUTION_TYPES: CaseResolutionType[] = [
+  "found_deceased",
+  "false_report",
+];
+
+/** Resolution types that trigger positive outcome workflows */
+export const POSITIVE_RESOLUTION_TYPES: CaseResolutionType[] = [
+  "found_safe",
+  "returned_home",
+  "located_elsewhere",
+];
+
+/** Resolution type labels for display */
+export const RESOLUTION_TYPE_LABELS: Record<CaseResolutionType, string> = {
+  found_safe: "Found safe",
+  found_deceased: "Found deceased",
+  returned_home: "Returned home",
+  located_elsewhere: "Located elsewhere",
+  closed_insufficient_info: "Closed - insufficient info",
+  false_report: "False report",
+  unfounded: "Unfounded",
+  duplicate: "Duplicate",
+  cancelled: "Cancelled",
+  transferred: "Transferred",
+  other: "Other",
+};
+
+/** Resolution type descriptions for user guidance */
+export const RESOLUTION_TYPE_DESCRIPTIONS: Record<CaseResolutionType, string> = {
+  found_safe: "Person has been located and confirmed safe. Location confirmed, notify family.",
+  found_deceased: "Person has been confirmed deceased. Requires sensitive handling and grief resources.",
+  returned_home: "Person has voluntarily returned home. Self-return documented.",
+  located_elsewhere: "Person has been located living elsewhere. New location confirmed.",
+  closed_insufficient_info: "Case archived due to insufficient information. Can be reopened.",
+  false_report: "Case determined to be a false report. Flagged, no public data retained.",
+  unfounded: "Investigation found no basis for the missing person report.",
+  duplicate: "This case is a duplicate of another existing case.",
+  cancelled: "Case cancelled at the request of the reporting party.",
+  transferred: "Case transferred to another jurisdiction or agency.",
+  other: "Other resolution type not covered by standard categories.",
+};
 
 export interface CaseResolutionRecord {
   id: string;


### PR DESCRIPTION
Closes #91

## Summary
- Added case resolution workflow with expanded status options:
  - **Positive outcomes**: Found safe, Returned home, Located elsewhere
  - **Neutral closures**: Closed - insufficient info, Unfounded, Duplicate, Cancelled, Transferred, Other
  - **Sensitive outcomes**: Found deceased, False report (with confirmation dialogs)
- Confirmation dialogs for sensitive outcomes requiring typed CONFIRM acknowledgment
- Success story consent option for positive resolutions
- Resolution history tracking with detailed event logging (statistics compilation, resource deactivation, lead archival)
- Updated case status mapping based on resolution type
- Post-resolution actions info panel showing automated actions on case closure

## Changes
- `src/types/case-resolution.types.ts` - Added new resolution types and helper constants
- `src/components/cases/ResolutionConfirmDialog.tsx` - New confirmation dialog component
- `src/components/cases/CaseResolutionPanel.tsx` - Enhanced with new features
- `src/app/api/cases/[caseId]/resolution/route.ts` - Updated API with new event logging

## Test Plan
- [x] pnpm build passes
- [ ] Manual testing of resolution workflow
- [ ] Verify confirmation dialogs appear for sensitive outcomes
- [ ] Verify success story section appears for positive outcomes

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded resolution types with categorized outcomes (positive, neutral, sensitive) and descriptive labels
  * Added confirmation dialog for sensitive case closures with required user verification
  * Introduced success story consent and notes capture for positive resolutions
  * New post-resolution actions informational block
  * Enhanced case status mapping based on resolution type
  * Improved event logging with outcome category and consent metadata

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->